### PR TITLE
Overlay timeout (minutes) and style timeout (ticks)

### DIFF
--- a/src/main/java/com/monkeymetrics/AttackMetrics.java
+++ b/src/main/java/com/monkeymetrics/AttackMetrics.java
@@ -41,5 +41,5 @@ public class AttackMetrics
 	private final Map<Skill, Integer> gainedExp = new HashMap<>();
 
 	@Nullable
-	private Instant lastAttackAction;
+	private Instant lastAttack;
 }

--- a/src/main/java/com/monkeymetrics/AttackMetrics.java
+++ b/src/main/java/com/monkeymetrics/AttackMetrics.java
@@ -24,15 +24,22 @@
  */
 package com.monkeymetrics;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 import lombok.Data;
 import net.runelite.api.Skill;
 
 @Data
 public class AttackMetrics
 {
-    private int hitsplats = 0;
-    private int damage = 0;
-    private final Map<Skill, Integer> gainedExp = new HashMap<>();
+	private boolean active = false;
+
+	private int hitsplats = 0;
+	private int damage = 0;
+	private final Map<Skill, Integer> gainedExp = new HashMap<>();
+
+	@Nullable
+	private Instant lastAttackAction;
 }

--- a/src/main/java/com/monkeymetrics/AttackMetricsOverlay.java
+++ b/src/main/java/com/monkeymetrics/AttackMetricsOverlay.java
@@ -56,6 +56,9 @@ public class AttackMetricsOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
+		// If Metrics overlay disabled,
+		// metrics are null and timeout is enabled
+		// or metrics are marked inactive.
 		if (!config.showMetrics()
 			|| (metrics == null && config.overlayTimeout() != 0)
 			|| !metrics.isActive())
@@ -84,7 +87,7 @@ public class AttackMetricsOverlay extends Overlay
 					.right(metrics.getDamage() + " hp")
 					.build());
 
-			metrics.getGainedExp().forEach(this::addActiveStyle);
+			metrics.getGainedExp().forEach(this::appendActiveStyle);
 		}
 		else
 		{
@@ -97,18 +100,21 @@ public class AttackMetricsOverlay extends Overlay
 		return panelComponent.render(graphics);
 	}
 
-	private void addActiveStyle(Skill skill, Integer exp)
+	private void appendActiveStyle(Skill skill, Integer exp)
 	{
 		int timeout = config.attackStyleTimeout();
-		// check whether timed out, if setting active and exp last tick was 0
+		// Check if the setting is enabled, and check if no XP was gained last tick
 		if (timeout != 0 && exp == 0)
 		{
-			int ticks = plugin.getTicksSinceExp().getOrDefault(skill, -1);
+			// Get how many game ticks since last attack
+			int ticks = plugin.getTicksSinceExpDrop().getOrDefault(skill, -1);
+			// If skill has not been tracked, or ticks since last attack >= timeout
 			if (ticks == -1 || ticks >= timeout)
 			{
 				return;
 			}
 		}
+
 		panelComponent.getChildren().add(
 			LineComponent.builder()
 				.left(skill.getName())

--- a/src/main/java/com/monkeymetrics/MonkeyMetricsConfig.java
+++ b/src/main/java/com/monkeymetrics/MonkeyMetricsConfig.java
@@ -27,6 +27,7 @@ package com.monkeymetrics;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Units;
 
 @ConfigGroup(MonkeyMetricsPlugin.CONFIG_KEY)
 public interface MonkeyMetricsConfig extends Config
@@ -63,4 +64,29 @@ public interface MonkeyMetricsConfig extends Config
 	{
 		return 2;
 	}
+
+	@ConfigItem(
+		position = 4,
+		keyName = "overlayTimeout",
+		name = "Overlay timeout",
+		description = "The time until the overlay is hidden (0 = always visible)"
+	)
+	@Units(Units.MINUTES)
+	default int overlayTimeout()
+	{
+		return 2;
+	}
+
+	@ConfigItem(
+		position = 5,
+		keyName = "attackStyleTimeout",
+		name = "Hide attack style",
+		description = "The time until an attack style expires (0 = Always visible)"
+	)
+	@Units(Units.TICKS)
+	default int attackStyleTimeout()
+	{
+		return 10;
+	}
+
 }


### PR DESCRIPTION
I'd like to leave this plugin running when not in use, however the overlay will stay visible until the end of the play session once activated.

I've added a couple of settings which relate to:
- Hiding the overlay after a period of inactivity*
- Hiding an attack style after a number of ticks (without receiving XP in the style)

\* Activity is considered as two or more hitsplats in a game tick.

A use case for the attack style timeout would be aggroing mobs with a thrown weapon (darts, knives, etc.), before bursting them. The ranged attack style is currently tracked/shown in the overlay, though we're not actively using that attack style until we need to aggro the mob again.

Unsure if the following code is a good approach, but I figured it's at least a decent enough demonstration of the idea.